### PR TITLE
Truncating part 2 and adding Powershell warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ You will be using [Azure Resource Manager](https://docs.microsoft.com/en-us/azur
    
 7. The resources will begin to deploy. This may take up to 10 minutes.
 
+8. NOTE: if you are running a very recent version of Powershell, you may have an issue with running the script. In this case, since there are only 4 resources, you can try to create them manually (examine the script to see the parameters set). 
+
 ---
 
 ## <a name="part1"></a>Part 1: Creating A Database and Collection To Load Data Into 
@@ -116,14 +118,7 @@ An Azure Cosmos DB collection is a container for data records. You will now crea
 ---
 
 ## <a name="part2"></a>Part 2: Creating A Leases Collection for Change Feed Processing
-The lease collection coordinates processing the change feed across multiple workers. A separate collection is used to store the leases with one lease per partition.
-
-1. Return to **Data Explorer** and select **New Collection** from the menu on the top of the page. Then perform the following actions:   
-	a. In the **Database id** field, select **Use existing**, then enter **changefeedlabdatabase**.  
-	b. In the **Collection id** field, enter **leases**.  
-    c. For **Storage capacity**, select **Fixed**.   
-	d. Leave the **Throughput** field set to its default value.  
-	e. Click the **OK** button.  
+The lease collection coordinates processing the change feed across multiple workers. A separate collection is used to store the leases with one lease per partition. ChangeFeedProcessor.cs does this automatically by setting CreateLeaseCollectionIfNotExists = true, so you do not need to do anything here. When running the solution end-to-end, observe that a collection named "leases" is created. 
 
 ---
 


### PR DESCRIPTION
Truncated the instructions in part 2 to account for the fact that leases collection is now created automatically in ChangeFeedProcessor.cs. This needed to be changed because creating a fixed collection from the portal (as instructed originally) has been disallowed. Also added a warning about possible Powershell errors when running on the latest version of Powershell.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->